### PR TITLE
Multi-target .NET Framework and .NET Standard

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,3 +31,4 @@ jobs:
       run: |
         dotnet nuget add source ${{ github.workspace }}/pack -n="LocalNLopt"
         dotnet build -c Release ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
+        dotnet test --no-build -c Release --verbosity normal ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,8 +26,9 @@ jobs:
     - name: Pack
       run: dotnet pack --no-build -c Release /p:PackageVersion=0.0.0-local
     - name: Test
-      run: dotnet test --no-build -c Release --verbosity normal
+      run: dotnet test --no-build -c Release
     - name: Test package
       run: |
         dotnet nuget add source ${{ github.workspace }}/pack -n="LocalNLopt"
-        dotnet test -c Release --verbosity normal ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
+        dotnet test ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj -c Release /property:Platform="AnyCPU" 
+        dotnet test ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj -c Release /property:Platform="x64"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,5 +30,4 @@ jobs:
     - name: Test package
       run: |
         dotnet nuget add source ${{ github.workspace }}/pack -n="LocalNLopt"
-        dotnet build -c Release ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
-        dotnet test --no-build -c Release --verbosity normal ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
+        dotnet test -c Release --verbosity normal ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj

--- a/NLoptNet.NuGet.Tests/SolverTests.cs
+++ b/NLoptNet.NuGet.Tests/SolverTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace NLoptNet.NuGet.Tests
 {

--- a/NLoptNet.NuGet.Tests/SolverTests.cs
+++ b/NLoptNet.NuGet.Tests/SolverTests.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace NLoptNet.NuGet.Tests
+{
+	[TestClass]
+	public class SolverTests
+	{
+		[TestMethod]
+		public void TestBasicParabolaNoDerivative()
+		{
+			for (int i = 0; i <= (int)NLoptAlgorithm.GN_ESCH; i++)
+			{
+				var algorithm = (NLoptAlgorithm)i;
+				var algStr = algorithm.ToString();
+				if (algStr.Contains("AUGLAG") || algStr.Contains("MLSL"))
+					continue;
+				if (algStr.Substring(0, 3).Contains("D_"))
+					continue;
+				var sw = Stopwatch.StartNew();
+				int count = 0;
+				using (var solver = new NLoptSolver(algorithm, 1, 0.01, 2000))
+				{
+					solver.SetLowerBounds(new[] { -10.0 });
+					solver.SetUpperBounds(new[] { 100.0 });
+					solver.SetMinObjective(variables =>
+					{
+						count++;
+						return Math.Pow(variables[0] - 3.0, 2.0) + 4.0;
+					});
+					double? final;
+					var data = new[] { 2.0 };
+					var result = solver.Optimize(data, out final);
+					//Assert.AreEqual(NloptResult.XTOL_REACHED, result);
+					//if (result == NloptResult.MAXEVAL_REACHED || result == NloptResult.XTOL_REACHED)
+					//Assert.AreEqual(4.0, final.Value, 0.1);
+					//	Assert.AreEqual(3.0, data[0], 0.01);
+					Trace.WriteLine(string.Format("D:{0:F3}, R:{1:F3}, A:{2}, {3}", data[0], final.GetValueOrDefault(-1), algorithm, result));
+				}
+				Trace.WriteLine("Elapsed: " + sw.ElapsedMilliseconds + "ms, Iterations: " + count);
+			}
+		}
+
+		[TestMethod]
+		public void TestBasicParabola()
+		{
+			for (int i = 0; i <= (int)NLoptAlgorithm.GN_ESCH; i++)
+			{
+				var algorithm = (NLoptAlgorithm)i;
+				var algStr = algorithm.ToString();
+				if (algStr.Contains("AUGLAG") || algStr.Contains("MLSL"))
+					continue;
+				var sw = Stopwatch.StartNew();
+				int count = 0;
+				using (var solver = new NLoptSolver(algorithm, 1, 0.0001, 2000))
+				{
+					solver.SetLowerBounds(new[] { -10.0 });
+					solver.SetUpperBounds(new[] { 100.0 });
+					solver.SetMinObjective((variables, gradient) =>
+					{
+						count++;
+						if (gradient != null)
+							gradient[0] = (variables[0] - 3.0) * 2.0;
+						return Math.Pow(variables[0] - 3.0, 2.0) + 4.0;
+					});
+					double? final;
+					var data = new[] { 2.0 };
+					var result = solver.Optimize(data, out final);
+					//Assert.AreEqual(NloptResult.XTOL_REACHED, result);
+					//if (result == NloptResult.MAXEVAL_REACHED || result == NloptResult.XTOL_REACHED)
+					//Assert.AreEqual(4.0, final.Value, 0.1);
+					//	Assert.AreEqual(3.0, data[0], 0.01);
+					Trace.WriteLine(string.Format("D:{0:F3}, R:{1:F3}, A:{2}, {3}", data[0], final.GetValueOrDefault(-1), algorithm, result));
+				}
+				Trace.WriteLine("Elapsed: " + sw.ElapsedMilliseconds + "ms, Iterations: " + count);
+			}
+		}
+
+		[TestMethod]
+		public void FindParabolaMinimum()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LN_COBYLA, 1, 0.001, 100))
+			{
+				solver.SetLowerBounds(new[] { -10.0 });
+				solver.SetUpperBounds(new[] { 100.0 });
+
+				solver.SetMinObjective(variables => Math.Pow(variables[0] - 3.0, 2.0) + 4.0);
+				double? finalScore;
+				var initialValue = new[] { 2.0 };
+				var result = solver.Optimize(initialValue, out finalScore);
+
+				Assert.AreEqual(NloptResult.XTOL_REACHED, result);
+				Assert.AreEqual(3.0, initialValue[0], 0.1);
+				Assert.AreEqual(4.0, finalScore.GetValueOrDefault(), 0.1);
+			}
+		}
+
+		[TestMethod]
+		public void FindParabolaMinimumWithDerivative()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LD_AUGLAG, 1, 0.01, 100, NLoptAlgorithm.LN_NELDERMEAD))
+			{
+				solver.SetLowerBounds(new[] { -10.0 });
+				solver.SetUpperBounds(new[] { 100.0 });
+				solver.AddLessOrEqualZeroConstraint((variables, gradient) =>
+				{
+					if (gradient != null)
+						gradient[0] = 1.0;
+					return variables[0] - 100.0;
+				});
+				solver.SetMinObjective((variables, gradient) =>
+				{
+					if (gradient != null)
+						gradient[0] = (variables[0] - 3.0) * 2.0;
+					return Math.Pow(variables[0] - 3.0, 2.0) + 4.0;
+				});
+				double? finalScore;
+				var initialValue = new[] { 2.0 };
+				var result = solver.Optimize(initialValue, out finalScore);
+
+				Assert.AreEqual(3.0, initialValue[0], 0.01);
+				Assert.AreEqual(4.0, finalScore.GetValueOrDefault(), 0.01);
+			}
+		}
+
+		[TestMethod]
+		public void SetAndGetAbsToleranceFuncVal()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LD_AUGLAG, 1, 0.01, 100, NLoptAlgorithm.LN_NELDERMEAD))
+			{
+				const double expectedValue = Math.PI;
+
+				solver.SetAbsoluteToleranceOnFunctionValue(expectedValue);
+				var solverTolerance = solver.GetAbsoluteToleranceOnFunctionValue();
+
+				Assert.AreEqual(expectedValue, solverTolerance);
+			}
+		}
+
+		[TestMethod]
+		public void SetAndGetRelToleranceFuncVal()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LD_AUGLAG, 1, 0.01, 100, NLoptAlgorithm.LN_NELDERMEAD))
+			{
+				const double expectedValue = Math.PI;
+
+				solver.SetRelativeToleranceOnFunctionValue(expectedValue);
+				var solverTolerance = solver.GetRelativeToleranceOnFunctionValue();
+
+				Assert.AreEqual(expectedValue, solverTolerance);
+			}
+		}
+
+		[TestMethod]
+		public void SetAndGetRelToleranceOptParam()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LD_AUGLAG, 1, 0.01, 100, NLoptAlgorithm.LN_NELDERMEAD))
+			{
+				const double expectedValue = Math.PI;
+
+				solver.SetRelativeToleranceOnOptimizationParameter(expectedValue);
+				var solverTolerance = solver.GetRelativeToleranceOnOptimizationParameter();
+
+				Assert.AreEqual(expectedValue, solverTolerance);
+			}
+		}
+	}
+}

--- a/NLoptNet/NLoptNet.csproj
+++ b/NLoptNet/NLoptNet.csproj
@@ -35,37 +35,37 @@
     <None Include="Signer.pfx" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="runtimes\linux-arm64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-arm64/native/nlopt.so">
+    <None Include="runtimes\linux-arm64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-arm64/native/nlopt.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\linux-x64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-x64/native/nlopt.so">
+    <None Include="runtimes\linux-x64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-x64/native/nlopt.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\linux-musl-x64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-musl-x64/native/nlopt.so">
+    <None Include="runtimes\linux-musl-x64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-musl-x64/native/nlopt.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x64\native\nlopt.dll" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.dll">
+    <None Include="runtimes\win-x64\native\nlopt.dll" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x64\native\nlopt.exp" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.exp">
+    <None Include="runtimes\win-x64\native\nlopt.exp" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.exp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x64\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.lib">
+    <None Include="runtimes\win-x64\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.lib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x86\native\nlopt.dll" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.dll">
+    <None Include="runtimes\win-x86\native\nlopt.dll" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x86\native\nlopt.exp" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.exp">
+    <None Include="runtimes\win-x86\native\nlopt.exp" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.exp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x86\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.lib">
+    <None Include="runtimes\win-x86\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.lib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x86\native\nlopt.dll" Pack="true" PackagePath="lib/net47/nlopt_x32.dll">
+    <None Include="runtimes\win-x86\native\nlopt.dll" Pack="true" PackagePath="lib/net47/nlopt_x32.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x64\native\nlopt.dll" Pack="true" PackagePath="lib/net47/nlopt_x64.dll">
+    <None Include="runtimes\win-x64\native\nlopt.dll" Pack="true" PackagePath="lib/net47/nlopt_x64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/NLoptNet/NLoptNet.csproj
+++ b/NLoptNet/NLoptNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
     <RootNamespace>NLoptNet</RootNamespace>
     <PackageVersion>2.0.0</PackageVersion>
 	<Platforms>AnyCPU;x64</Platforms>
@@ -60,6 +60,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="runtimes\win-x86\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.lib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="runtimes\win-x86\native\nlopt.dll" Pack="true" PackagePath="lib/net47/nlopt_x32.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="runtimes\win-x64\native\nlopt.dll" Pack="true" PackagePath="lib/net47/nlopt_x64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/NLoptNet/NLoptSolver.cs
+++ b/NLoptNet/NLoptSolver.cs
@@ -12,7 +12,7 @@ namespace NLoptNet
 	/// <summary>
 	/// This class wraps the NLopt C library. Be sure to dispose it when done.
 	/// </summary>
-	public class NLoptSolver : IDisposable
+	public partial class NLoptSolver : IDisposable
 	{
 #if MONO
 				[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -53,85 +53,6 @@ namespace NLoptNet
 			IntPtr data
 		);
 #endif
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void nlopt_version(out int major, out int minor, out int bugfix);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern IntPtr nlopt_create(NLoptAlgorithm algorithm, uint n);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void nlopt_destroy(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-		private static extern NloptResult nlopt_optimize(IntPtr opt, double[] x, ref double result);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_min_objective(IntPtr opt, nlopt_func f, IntPtr data);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_max_objective(IntPtr opt, nlopt_func f, IntPtr data);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NLoptAlgorithm nlopt_get_algorithm(IntPtr opt);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern uint nlopt_get_dimension(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_lower_bounds(IntPtr opt, double[] lowerBounds);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_upper_bounds(IntPtr opt, double[] upperBounds);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_add_inequality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_add_equality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_add_equality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_add_inequality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_xtol_rel(IntPtr opt, double tolerance);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_local_optimizer(IntPtr opt, IntPtr local);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void nlopt_set_maxeval(IntPtr opt, int maxeval);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_force_stop(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_initial_step(IntPtr opt, double[] dx);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_initial_step1(IntPtr opt, double dx);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_ftol_rel(IntPtr opt, double tol);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_ftol_abs(IntPtr opt, double tol);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_xtol_abs1(IntPtr opt, double tol);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_xtol_abs(IntPtr opt, double[] tol);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern double nlopt_get_ftol_rel(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern double nlopt_get_ftol_abs(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern double nlopt_get_xtol_rel(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_get_xtol_abs(IntPtr opt, out double[] tol);
 
 		private IntPtr _opt;
 		private readonly Dictionary<Delegate, nlopt_func> _funcCache = new Dictionary<Delegate, nlopt_func>();

--- a/NLoptNet/NLoptSolver_netfx.cs
+++ b/NLoptNet/NLoptSolver_netfx.cs
@@ -1,0 +1,303 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace NLoptNet
+{
+	public partial class NLoptSolver
+	{
+		private static bool Is64Bit => IntPtr.Size == 8;
+		private const string Subscript32 = @"_x32";
+		private const string Subscript64 = @"_x64";
+		private static string Subscript => Is64Bit ? Subscript64 : Subscript32;
+		private const string NLopt32 = "nlopt_x32.dll";
+		private const string NLopt64 = "nlopt_x64.dll";
+
+		[DllImport("kernel32", SetLastError = true)]
+		private static extern IntPtr LoadLibrary(string lpFileName);
+		
+		#region Imported NLOpt functions - .NET Framework
+		
+		#if NETFRAMEWORK
+		
+		static NLoptSolver()
+		{
+			LoadLibrary($"nlopt_{Subscript}.dll");
+		}
+		
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_version), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_version64(out int major, out int minor, out int bugfix);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_version), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_version32(out int major, out int minor, out int bugfix);
+		
+		private static void nlopt_version(out int major, out int minor, out int bugfix)
+		{
+			if (Is64Bit)
+			{
+				nlopt_version64(out major, out minor, out bugfix);
+				return;
+			}
+
+			nlopt_version32(out major, out minor, out bugfix);
+		}
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_create), CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr nlopt_create64(NLoptAlgorithm algorithm, uint n);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_create), CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr nlopt_create32(NLoptAlgorithm algorithm, uint n);
+
+		private static IntPtr nlopt_create(NLoptAlgorithm algorithm, uint n)
+			=> Is64Bit ? nlopt_create64(algorithm, n) : nlopt_create32(algorithm, n);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_destroy), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_destroy64(IntPtr opt);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_destroy), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_destroy32(IntPtr opt);
+
+		private static void nlopt_destroy(IntPtr opt)
+		{
+			if (Is64Bit)
+			{
+				nlopt_destroy64(opt);
+				return;
+			}
+
+			nlopt_destroy32(opt);
+		}
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_optimize), CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+		private static extern NloptResult nlopt_optimize64(IntPtr opt, double[] x, ref double result);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_optimize), CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+		private static extern NloptResult nlopt_optimize32(IntPtr opt, double[] x, ref double result);
+
+		private static NloptResult nlopt_optimize(IntPtr opt, double[] x, ref double result)
+			=> Is64Bit ? nlopt_optimize64(opt, x, ref result) : nlopt_optimize32(opt, x, ref result);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_min_objective), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_min_objective64(IntPtr opt, nlopt_func f, IntPtr data);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_min_objective), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_min_objective32(IntPtr opt, nlopt_func f, IntPtr data);
+
+		private static NloptResult nlopt_set_min_objective(IntPtr opt, nlopt_func f, IntPtr data)
+			=> Is64Bit ? nlopt_set_min_objective64(opt, f, data) : nlopt_set_min_objective32(opt, f, data);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_max_objective), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_max_objective64(IntPtr opt, nlopt_func f, IntPtr data);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_max_objective), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_max_objective32(IntPtr opt, nlopt_func f, IntPtr data);
+
+		private static NloptResult nlopt_set_max_objective(IntPtr opt, nlopt_func f, IntPtr data)
+			=> Is64Bit ? nlopt_set_max_objective64(opt, f, data) : nlopt_set_max_objective32(opt, f, data);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_get_algorithm), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NLoptAlgorithm nlopt_get_algorithm64(IntPtr opt);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_get_algorithm), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NLoptAlgorithm nlopt_get_algorithm32(IntPtr opt);
+
+		private static NLoptAlgorithm nlopt_get_algorithm(IntPtr opt)
+			=> Is64Bit ? nlopt_get_algorithm64(opt) : nlopt_get_algorithm32(opt);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_get_dimension), CallingConvention = CallingConvention.Cdecl)]
+		private static extern uint nlopt_get_dimension64(IntPtr opt);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_get_dimension), CallingConvention = CallingConvention.Cdecl)]
+		private static extern uint nlopt_get_dimension32(IntPtr opt);
+
+		private static uint nlopt_get_dimension(IntPtr opt)
+			=> Is64Bit ? nlopt_get_dimension64(opt) : nlopt_get_dimension32(opt);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_lower_bounds), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_lower_bounds64(IntPtr opt, double[] lowerBounds);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_lower_bounds), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_lower_bounds32(IntPtr opt, double[] lowerBounds);
+
+		private static NloptResult nlopt_set_lower_bounds(IntPtr opt, double[] lowerBounds)
+			=> Is64Bit ? nlopt_set_lower_bounds64(opt, lowerBounds) : nlopt_set_lower_bounds32(opt, lowerBounds);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_upper_bounds), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_upper_bounds64(IntPtr opt, double[] upperBounds);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_upper_bounds), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_upper_bounds32(IntPtr opt, double[] upperBounds);
+
+		private static NloptResult nlopt_set_upper_bounds(IntPtr opt, double[] upperBounds)
+			=> Is64Bit ? nlopt_set_upper_bounds64(opt, upperBounds) : nlopt_set_upper_bounds32(opt, upperBounds);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_add_inequality_constraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_constraint64(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_add_inequality_constraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_constraint32(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		private static NloptResult nlopt_add_inequality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance)
+			=> Is64Bit ? nlopt_add_inequality_constraint64(opt, fc, data, tolerance) : nlopt_add_inequality_constraint32(opt, fc, data, tolerance);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_add_equality_constraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_constraint64(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_add_equality_constraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_constraint32(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		private static NloptResult nlopt_add_equality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance)
+			=> Is64Bit ? nlopt_add_equality_constraint64(opt, fc, data, tolerance) : nlopt_add_equality_constraint32(opt, fc, data, tolerance);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_add_equality_mconstraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_mconstraint64(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_add_equality_mconstraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_mconstraint32(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		
+		private static NloptResult nlopt_add_equality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances)
+			=> Is64Bit ? nlopt_add_equality_mconstraint64(opt, m, fc, data, tolerances) : nlopt_add_equality_mconstraint32(opt, m, fc, data, tolerances);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_add_inequality_mconstraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_mconstraint64(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_add_inequality_mconstraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_mconstraint32(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		
+		private static NloptResult nlopt_add_inequality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances)
+			=> Is64Bit ? nlopt_add_inequality_mconstraint64(opt, m, fc, data, tolerances) : nlopt_add_inequality_mconstraint32(opt, m, fc, data, tolerances);
+		
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_xtol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_rel64(IntPtr opt, double tolerance);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_xtol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_rel32(IntPtr opt, double tolerance);
+
+		private static NloptResult nlopt_set_xtol_rel(IntPtr opt, double tolerance)
+			=> Is64Bit ? nlopt_set_xtol_rel64(opt, tolerance) : nlopt_set_xtol_rel32(opt, tolerance);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_local_optimizer), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_local_optimizer64(IntPtr opt, IntPtr local);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_local_optimizer), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_local_optimizer32(IntPtr opt, IntPtr local);
+
+		private static NloptResult nlopt_set_local_optimizer(IntPtr opt, IntPtr local)
+			=> Is64Bit ? nlopt_set_local_optimizer64(opt, local) : nlopt_set_local_optimizer32(opt, local);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_maxeval), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_set_maxeval64(IntPtr opt, int maxeval);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_maxeval), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_set_maxeval32(IntPtr opt, int maxeval);
+
+		private static void nlopt_set_maxeval(IntPtr opt, int maxeval)
+		{
+			if (Is64Bit)
+			{
+				nlopt_set_maxeval64(opt, maxeval);
+				return;
+			}
+
+			nlopt_set_maxeval32(opt, maxeval);
+		}
+		
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_force_stop), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_force_stop64(IntPtr opt);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_force_stop), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_force_stop32(IntPtr opt);
+
+		private static NloptResult nlopt_force_stop(IntPtr opt)
+		{
+			return Is64Bit ? nlopt_force_stop64(opt) : nlopt_force_stop32(opt);
+		}
+	        
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_initial_step), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step64(IntPtr opt, double[] dx);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_initial_step), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step32(IntPtr opt, double[] dx);
+
+		private static NloptResult nlopt_set_initial_step(IntPtr opt, double[] dx)
+			=> Is64Bit ? nlopt_set_initial_step64(opt, dx) : nlopt_set_initial_step32(opt, dx);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step1(IntPtr opt, double dx);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_ftol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_rel64(IntPtr opt, double tol);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_ftol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_rel32(IntPtr opt, double tol);
+
+		private static NloptResult nlopt_set_ftol_rel(IntPtr opt, double tol)
+			=> Is64Bit ? nlopt_set_ftol_rel64(opt, tol) : nlopt_set_ftol_rel32(opt, tol);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_ftol_abs), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_abs64(IntPtr opt, double tol);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_ftol_abs), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_abs32(IntPtr opt, double tol);
+
+		private static NloptResult nlopt_set_ftol_abs(IntPtr opt, double tol)
+			=> Is64Bit ? nlopt_set_ftol_abs64(opt, tol) : nlopt_set_ftol_abs32(opt, tol);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_xtol_abs1), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern NloptResult nlopt_set_xtol_abs164(IntPtr opt, double tol);
+
+	    [DllImport(NLopt32, EntryPoint = nameof(nlopt_set_xtol_abs1), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern NloptResult nlopt_set_xtol_abs132(IntPtr opt, double tol);
+
+	    private static NloptResult nlopt_set_xtol_abs1(IntPtr opt, double tol)
+		    => Is64Bit ? nlopt_set_xtol_abs164(opt, tol) : nlopt_set_xtol_abs132(opt, tol);
+
+	    [DllImport(NLopt64, EntryPoint = nameof(nlopt_set_xtol_abs), CallingConvention = CallingConvention.Cdecl)]
+        private static extern NloptResult nlopt_set_xtol_abs64(IntPtr opt, double tol);
+
+        [DllImport(NLopt32, EntryPoint = nameof(nlopt_set_xtol_abs), CallingConvention = CallingConvention.Cdecl)]
+        private static extern NloptResult nlopt_set_xtol_abs32(IntPtr opt, double tol);
+
+        private static NloptResult nlopt_set_xtol_abs(IntPtr opt, double tol)
+	        => Is64Bit ? nlopt_set_xtol_abs64(opt, tol) : nlopt_set_xtol_abs32(opt, tol);
+
+        [DllImport(NLopt64, EntryPoint = nameof(nlopt_get_ftol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern double nlopt_get_ftol_rel64(IntPtr opt);
+
+	    [DllImport(NLopt32, EntryPoint = nameof(nlopt_get_ftol_rel), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_ftol_rel32(IntPtr opt);
+
+	    private static double nlopt_get_ftol_rel(IntPtr opt)
+		    => Is64Bit ? nlopt_get_ftol_rel64(opt) : nlopt_get_ftol_rel32(opt);
+
+	    [DllImport(NLopt64, EntryPoint = nameof(nlopt_get_ftol_abs), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_ftol_abs64(IntPtr opt);
+
+	    [DllImport(NLopt32, EntryPoint = nameof(nlopt_get_ftol_abs), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_ftol_abs32(IntPtr opt);
+
+	    private static double nlopt_get_ftol_abs(IntPtr opt)
+		    => Is64Bit ? nlopt_get_ftol_abs64(opt) : nlopt_get_ftol_abs32(opt);
+
+	    [DllImport(NLopt64, EntryPoint = nameof(nlopt_get_xtol_rel), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_xtol_rel64(IntPtr opt);
+
+	    [DllImport(NLopt32, EntryPoint = nameof(nlopt_get_xtol_rel), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_xtol_rel32(IntPtr opt);
+
+	    private static double nlopt_get_xtol_rel(IntPtr opt)
+		    => Is64Bit ? nlopt_get_xtol_rel64(opt) : nlopt_get_xtol_rel32(opt);
+
+	    [DllImport(NLopt64, EntryPoint = nameof(nlopt_get_xtol_abs), CallingConvention = CallingConvention.Cdecl)]
+        private static extern double nlopt_get_xtol_abs64(IntPtr opt);
+
+        [DllImport(NLopt32, EntryPoint = nameof(nlopt_get_xtol_abs), CallingConvention = CallingConvention.Cdecl)]
+        private static extern double nlopt_get_xtol_abs32(IntPtr opt);
+
+        private static double nlopt_get_xtol_abs(IntPtr opt)
+	        => Is64Bit ? nlopt_get_xtol_abs64(opt) : nlopt_get_xtol_abs32(opt);
+
+        #endif
+        
+        #endregion
+	}
+}

--- a/NLoptNet/NLoptSolver_netstandard.cs
+++ b/NLoptNet/NLoptSolver_netstandard.cs
@@ -1,0 +1,95 @@
+﻿namespace NLoptNet
+{
+	using System;
+	using System.Runtime.InteropServices;
+	
+    public partial class NLoptSolver
+    {
+		#region Imported NLOpt functions - .NET Standard
+		
+		#if NETSTANDARD
+		
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_version(out int major, out int minor, out int bugfix);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr nlopt_create(NLoptAlgorithm algorithm, uint n);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_destroy(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+		private static extern NloptResult nlopt_optimize(IntPtr opt, double[] x, ref double result);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_min_objective(IntPtr opt, nlopt_func f, IntPtr data);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_max_objective(IntPtr opt, nlopt_func f, IntPtr data);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NLoptAlgorithm nlopt_get_algorithm(IntPtr opt);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern uint nlopt_get_dimension(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_lower_bounds(IntPtr opt, double[] lowerBounds);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_upper_bounds(IntPtr opt, double[] upperBounds);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_rel(IntPtr opt, double tolerance);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_local_optimizer(IntPtr opt, IntPtr local);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_set_maxeval(IntPtr opt, int maxeval);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_force_stop(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step(IntPtr opt, double[] dx);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step1(IntPtr opt, double dx);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_rel(IntPtr opt, double tol);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_abs(IntPtr opt, double tol);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_abs1(IntPtr opt, double tol);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_abs(IntPtr opt, double[] tol);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern double nlopt_get_ftol_rel(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern double nlopt_get_ftol_abs(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern double nlopt_get_xtol_rel(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_get_xtol_abs(IntPtr opt, out double[] tol);
+
+		#endif
+		
+		#endregion
+    }
+}


### PR DESCRIPTION
In this PR we allow for multi-targetting to .NET 4.7 and .NET Standard 2.0:
* For .NET 4.7 compatibility, note that the assemblies need to end up in lib/net47 - see e.g. [this post](https://stackoverflow.com/questions/52397501/nuget-references-to-assemblies-in-runtimes-folder-not-added) explaining this - interestingly, the original `<None Update=...>` syntax no longer works when `TargetFramework `is changed to `TargetFrameworks`, but needs to be amended to `<None Include=...>`
* I have not been able to find out how to put native assemblies in subfolders, to avoid naming conflicts therefore the 32-bit and 64-bit versions have their own name (nlopt_x32.dll and nlopt_x64.dll)
* NLoptSolver has been modified to this end - it has a .NET Framework specific version, that uses LoadLibrary to load either the 32-bit or 64-bit version. For .NET Standard the previous version worked fine.
* Note that when the assembly is referenced via NuGet, the LoadLibrary call in the user code is no longer necessary

To demonstrate that all is working, the NLoptNet.NuGet.Tests assembly is run under .NET 4.7, .NET 4.8, .NET Core 3.1 and .NET 6.0. All tests pass.